### PR TITLE
Fix template

### DIFF
--- a/fluent-bit-template.go
+++ b/fluent-bit-template.go
@@ -19,7 +19,9 @@ var fluentBitConfigTemplate = `{{- range .IncludeConfigHeadOfFile -}}
 {{- range .Inputs }}
 [INPUT]
     Name {{ .Name }}
-    {{- if .Tag }}Tag {{ .Tag }}{{- end }}
+    {{- if .Tag }}
+    Tag {{ .Tag }}
+    {{- end }}
     {{- range $key, $value := .Options }}
     {{ $key }} {{ $value }}
     {{- end }}

--- a/fluentd-template.go
+++ b/fluentd-template.go
@@ -19,7 +19,9 @@ var fluentDConfigTemplate = `{{- range .IncludeConfigHeadOfFile -}}
 {{- range .Inputs }}
 <source>
     @type {{ .Name }}
-    {{- if .Tag }}tag {{ .Tag }}{{- end }}
+    {{- if .Tag }}
+    tag {{ .Tag }}
+    {{- end }}
     {{- range $key, $value := .Options }}
     {{ $key }} {{ $value }}
     {{- end }}

--- a/generator_test.go
+++ b/generator_test.go
@@ -24,6 +24,7 @@ var expectedFluentBitConfig = `@INCLUDE /etc/head_file.conf
 
 [INPUT]
     Name forward
+    Tag tag
     Listen 127.0.0.1
     Port 24224
 
@@ -71,6 +72,7 @@ var expectedFluentDConfig = `@include /etc/head_file.conf
 
 <source>
     @type forward
+    tag tag
     Listen 127.0.0.1
     Port 24224
 </source>
@@ -126,7 +128,7 @@ var expectedFluentDConfig = `@include /etc/head_file.conf
 
 func TestGenerateConfig(t *testing.T) {
 	config := New()
-	config.AddInput("forward", "", map[string]string{
+	config.AddInput("forward", "tag", map[string]string{
 		"Listen": "127.0.0.1",
 		"Port":   "24224",
 	}).AddInput("forward", "", map[string]string{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add missing newline before input tag.

Test:
```
8c8590418780:go-config-generator-for-fluentd-and-fluentbit fenxiong$ go test -timeout=120s -v -cover ./...
=== RUN   TestGenerateConfig
--- PASS: TestGenerateConfig (0.00s)
PASS
coverage: 92.9% of statements
ok  	github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit	(cached)	coverage: 92.9% of statements
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
